### PR TITLE
Fix submenu sorting

### DIFF
--- a/extensions/actions-for-nautilus/afn_config.py
+++ b/extensions/actions-for-nautilus/afn_config.py
@@ -136,6 +136,7 @@ def _check_action(idString, action):
 #
 def _check_menu_action(idString, action):
     action["label"] = action["label"].strip() if "label" in action and type(action["label"]) == str else ""
+    action["sort"] = "sort" in action and action["sort"] == "auto"
     if (len(action["label"]) > 0 and
         "actions" in action and 
         type(action["actions"]) == list):

--- a/extensions/actions-for-nautilus/afn_menu.py
+++ b/extensions/actions-for-nautilus/afn_menu.py
@@ -60,7 +60,7 @@ def _create_submenu_menu_item(action, files, group, act_function):
 			label=action["label"],
 		)
 		menu_item.set_submenu(menu)
-		for menu_sub_item in (sorted(actions,key=lambda element: element.props.label) if action.get("action","manual") else actions):
+		for menu_sub_item in (sorted(actions,key=lambda element: element.props.label) if action["sort"] else actions):
 			menu.append_item(menu_sub_item)
 		return menu_item
 


### PR DESCRIPTION
Submenu sorting wasn't working. It does now with "manula" being the default as documented.