### PR TITLE
Import jquery from configurator's javascript folder instead of user's share directory

### DIFF
--- a/configurator/actions-for-nautilus-configurator.py
+++ b/configurator/actions-for-nautilus-configurator.py
@@ -69,7 +69,7 @@ docs = {
         "default": None
     },
     "/javascript/jquery.min.js": {
-        "path": "/usr/share/javascript/jquery/jquery.min.js",
+        "path": "./javascript/jquery.min.js",
         "mimetype": "application/javascript",
         "default": None
     },


### PR DESCRIPTION
Small fix which could be related to #9 - at least symptoms were identical in my case. Since jquery script is included in the source files anyway it seems there is no reason to rely on its existence in user's system (which may not be the case).