### PR TITLE
ROOKIE MISTAKE. Only open the server on 127.0.0.1

### DIFF
--- a/configurator/actions-for-nautilus-configurator.html
+++ b/configurator/actions-for-nautilus-configurator.html
@@ -47,7 +47,7 @@
 				data: ""
 			});
 		}
-		addEventListener("unload", onUnload);
+		addEventListener("beforeunload", onUnload);
 
 		let editor;
 

--- a/configurator/actions-for-nautilus-configurator.py
+++ b/configurator/actions-for-nautilus-configurator.py
@@ -221,7 +221,7 @@ class ActionsForNautilusRequestHandler(http.server.BaseHTTPRequestHandler):
 handler = ActionsForNautilusRequestHandler
 
 PORT = int(sys.argv[1])
-with http.server.ThreadingHTTPServer(("", PORT), handler) as httpd:
+with http.server.ThreadingHTTPServer(("127.0.0.1", PORT), handler) as httpd:
     print("localhost:" + str(httpd.server_address[1]))
     try:
         httpd.serve_forever()


### PR DESCRIPTION
I was instantiating the Python ThreadingHTTPServer class with the empty string as the server address! That's a reprehensible mistake!

This fixes that to be localhost.

I recreated the original problem with the main branch and tested again with this PR to prove that this fixes the issue.

I have also confirmed that the server itself is closed 
* When the UI tab is closed - in Chrome at least
* When the UI application is relaunched (closing the old server before starting the new one)