### PR TITLE
49 jquery gets 404 in configurator

### DIFF
--- a/configurator/actions-for-nautilus-configurator.py
+++ b/configurator/actions-for-nautilus-configurator.py
@@ -8,6 +8,7 @@ import datetime
 
 PORT = 8000
 HOME = os.environ.get('HOME')
+JQUERY = os.environ.get('JQUERY')
 
 # config_html = "./actions-for-nautilus-configurator.html"
 # cmdline_help = "./command-line-help.html"
@@ -69,7 +70,7 @@ docs = {
         "default": None
     },
     "/javascript/jquery.min.js": {
-        "path": "/usr/share/javascript/jquery/jquery.min.js",
+        "path": JQUERY,
         "mimetype": "application/javascript",
         "default": None
     },

--- a/configurator/start-configurator.sh
+++ b/configurator/start-configurator.sh
@@ -7,7 +7,7 @@ mkdir -p $HOME/.local/share/actions-for-nautilus
 
 [ -f $HOME/.local/share/actions-for-nautilus/config.json ] || cp ./sample-config.json $HOME/.local/share/actions-for-nautilus/config.json
 
-if [ -f $PWD/javascript/jquery.min.js ] then
+if [ -f $PWD/javascript/jquery.min.js ]; then
 	JQUERY=$PWD/javascript/jquery.min.js
 else
 	JQUERY=/usr/share/javascript/jquery/jquery.min.js

--- a/configurator/start-configurator.sh
+++ b/configurator/start-configurator.sh
@@ -7,8 +7,15 @@ mkdir -p $HOME/.local/share/actions-for-nautilus
 
 [ -f $HOME/.local/share/actions-for-nautilus/config.json ] || cp ./sample-config.json $HOME/.local/share/actions-for-nautilus/config.json
 
+if [ -f $PWD/javascript/jquery.min.js ] then
+	JQUERY=$PWD/javascript/jquery.min.js
+else
+	JQUERY=/usr/share/javascript/jquery/jquery.min.js
+fi
+export JQUERY
+
 #
-# Start the configuration server, the xdg-open the home page
+# Start the configuration server, then xdg-open the home page
 #
 
 #


### PR DESCRIPTION
The start scripts for the configurator insisted on jquery being in `/usr/share/javascript/jquery`. This may not be the case when the extension is installed via the makefile. The PR, then, changes the strategy to make the location of Jquery be an environment variable which is discovered or defaulted at execution time.